### PR TITLE
Remove SRI software packages from service list

### DIFF
--- a/Translator Server Info.md
+++ b/Translator Server Info.md
@@ -38,7 +38,4 @@ This page is a work in progress.  As we move through figuring out how to deploy 
 |SRI|Edge Normalizer|edgenormalization-sri.renci.org||
 |SRI|Node Normalization|nodenormalization-sri.renci.org||
 |SRI|BL Compliance Service|||
-|SRI|Plater|||
-|SRI|Reasoner-Pydantic|||
-|SRI|Reasoner-Validator|||
 |SRI|Reference KG|scigraph.ncats.io||


### PR DESCRIPTION
These are Python packages/project templates, not specific service instances. For the deployed Plater instances, see Ranking Agent's Automat.